### PR TITLE
fix: 403 error from github in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,6 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
Attempt to fix the authentication error during the release workflow

<img width="1327" alt="image" src="https://github.com/pmrotule/nuxt-request-timeline/assets/10983258/b945544d-2969-41b3-8f62-fdd87aa72f34">
